### PR TITLE
ocamlformatが走ったかをCIで確認する

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,26 @@
+name: Check formatting
+
+on:
+  pull_request:
+  push:
+    branches: ["main"]
+
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup OCaml
+        uses: ocaml/setup-ocaml@v3
+        with:
+          ocaml-compiler: 5.3.0
+
+      - run: opam install ocamlformat.0.27.0
+      - run: opam exec -- dune build @fmt


### PR DESCRIPTION
## やったこと

`dune build @fmt`を呼び出すとocamlformatによるフォーマッティングが走るのでそれをCIから走らせる

```
$ vim bin/main.ml # フォーマッタをかけずに編集
$ dune build @fmt
File "bin/main.ml", line 1, characters 0-0:
------ bin/main.ml
++++++ bin/.formatted/main.ml
File "bin/main.ml", line 40, characters 0-1:
 |      and+ metadata, content =
 |        Yocaml_yaml.Pipeline.read_file_with_metadata (module Archetype.Page) source
 |      in
 |      template (module Archetype.Page) ~metadata content)
 |;;
 |
 |let process () =
 |  let open Eff in
 |  let cache = Path.(into / ".cache") in
 |  Action.restore_cache cache
 |  >>= copy_favicon
 |  >>= create_css
 |  >>= create_index
 |  >>= Action.store_cache cache
 |;;
 |
-|  let () =
+|let () =
 |  let level = `Debug in
 |  let target = into in
 |  let port = 8080 in
 |  match Sys.argv with
 |  | [| _ |] | [| _; "build" |] -> Yocaml_unix.run ~level process
 |  | [| _; "serve" |] -> Yocaml_unix.serve ~level ~target ~port process
 |  | _ ->
 |    let open Printf in
 |    eprintf "Usage: %s [build|serve]\n" Sys.argv.(0);
 |    eprintf "  build  Generate static site (default)\n";
 |    eprintf "  serve  Start development server on port 8000\n";
 |    exit 1
 |;;
$ echo $?
1
```