### PR TITLE
モバイル端末でのイベントページのヘッダとタイトルが衝突する問題を修正

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -290,6 +290,7 @@ body {
 @media (max-width: 768px) {
   .page {
     padding: 1.5rem 1rem;
+    padding-top: 100px; /* Keep header offset on mobile */
   }
 
   .page h1 {


### PR DESCRIPTION
before:

<img height="800" alt="image" src="https://github.com/user-attachments/assets/02331a68-1be2-4e7a-92f3-b8c4cdde49fa" />
<img height="800" alt="image" src="https://github.com/user-attachments/assets/c1ef1dc7-ce28-47c6-8a58-4c9f8f078852" />

after:

<img height="800" alt="localhost_8000_events_" src="https://github.com/user-attachments/assets/fecc5620-fa9b-4394-beef-b3a93dc0f207" />
<img height="800" alt="localhost_8000_events_ocaml_meeting_2013 html" src="https://github.com/user-attachments/assets/09c396e3-84c1-41c5-a1ef-09c9a3d2b289" />

